### PR TITLE
Fix default_fanout_load

### DIFF
--- a/timing/sky130_fd_sc_hd__common.lib.json
+++ b/timing/sky130_fd_sc_hd__common.lib.json
@@ -13,7 +13,7 @@
   "current_unit": "1mA",
   "default_cell_leakage_power": 0.0,
   "default_constraint_arc_mode": "worst",
-  "default_fanout_load": 0.0,
+  "default_fanout_load": 1.0,
   "default_inout_pin_cap": 0.0,
   "default_input_pin_cap": 0.0,
   "default_leakage_power_density": 0.0,


### PR DESCRIPTION
default_fanout_load is currently 0, which means input pins have no
fanout load. Set it to a much more reasonable default of 1.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>